### PR TITLE
added mmsGroupId configuration. this is required from version 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This Docker run both `mongodb-mms-agent` and `munin-node`.
 
 ## Run this container
 
-        docker run --name mongodb-mms-agent --env "MMS_API_KEY=YOUR_MMS_GROUP_ID" --env "MMS_API_KEY=YOUR_MMS_KEY" --privileged --net=host neowaylabs/mongodb-mms-agent
+        docker run --name mongodb-mms-agent --env "MMS_GROUP_ID=YOUR_MMS_GROUP_ID" --env "MMS_API_KEY=YOUR_MMS_KEY" --privileged --net=host neowaylabs/mongodb-mms-agent
 
 
 > Note: You need change YOUR_MMS_GROUP_ID and YOUR_MMS_KEY. see also https://docs.cloudmanager.mongodb.com/reference/automation-agent/

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This Docker run both `mongodb-mms-agent` and `munin-node`.
 
 ## Run this container
 
-        docker run --name mongodb-mms-agent --env "MMS_API_KEY=YOUR_MMS_KEY" --privileged --net=host neowaylabs/mongodb-mms-agent
+        docker run --name mongodb-mms-agent --env "MMS_API_KEY=YOUR_MMS_GROUP_ID" --env "MMS_API_KEY=YOUR_MMS_KEY" --privileged --net=host neowaylabs/mongodb-mms-agent
 
 
-> Note: You need change YOUR_MMS_KEY
+> Note: You need change YOUR_MMS_GROUP_ID and YOUR_MMS_KEY. see also https://docs.cloudmanager.mongodb.com/reference/automation-agent/

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,10 +2,10 @@
 set -e
 
 # Setup mongodb-mms-agent
-if [ ! "$MMS_API_KEY" ]; then
+if [ ! "$MMS_API_KEY" ] || [ ! "$MMS_GROUP_ID" ]; then
     {
-        echo 'error: MMS_API_KEY was not specified'
-        echo 'try something like: docker run -e MMS_API_KEY=... ...'
+        echo 'error: MMS_API_KEY or MMS_GROUP_ID was not specified'
+        echo 'try something like: docker run -e MMS_API_KEY=... -w MMS_GROUP_ID=... ...'
         echo '(see https://mms.mongodb.com/settings/monitoring-agent for your mmsApiKey)'
         echo
     } >&2
@@ -23,6 +23,8 @@ set_config() {
 }
 
 set_config mmsApiKey "$MMS_API_KEY"
+
+set_config mmsGroupId "$MMS_GROUP_ID"
 
 cat "$config_tmp" > /etc/mongodb-mms/monitoring-agent.config
 rm "$config_tmp"


### PR DESCRIPTION
@lborguetti take a look. The new version 6 of agent requires mmsGroupId at configuration file /etc/mongodb-mms/monitoring-agent.config